### PR TITLE
Account for duplicate keys in VDF to JSON transformation

### DIFF
--- a/vdf.rb
+++ b/vdf.rb
@@ -3,7 +3,8 @@ require 'strscan'
 class VDF
   attr_reader :scanner
 
-  def initialize(string)
+  def initialize(string, allow_duplicate_keys)
+    @allow_duplicate_keys = allow_duplicate_keys
     @scanner = StringScanner.new(string)
   end
 
@@ -77,12 +78,22 @@ class VDF
       if hash_head
         key = scanner[1]
         value = kvs
-        hash[key] = value
+        if @allow_duplicate_keys && hash.key?(key)
+          hash[key] = [hash[key]] unless hash[key].is_a?(Array)
+          hash[key] << value
+        else
+          hash[key] = value
+        end
         ignorable
       elsif key = string
         ignorable
         if value = string
-          hash[key] = value
+          if @allow_duplicate_keys && hash.key?(key)
+            hash[key] = [hash[key]] unless hash[key].is_a?(Array)
+            hash[key] << value
+          else
+            hash[key] = value
+          end
         else
           raise "expected value"
         end


### PR DESCRIPTION
Valve's VDF format is pretty freeform - duplicate keys are permissible. Unfortunately it is hard to distinguish between errors and intentional duplicate keys. For most VDFs, duplicate keys appear to be errors (certain keys are specified more than once with the same value). However, in `items_game.txt` duplicate keys appear to serve a purpose. This PR allows us to specify specific files where duplicate keys are allowed, and transform the VDFs to JSON accordingly. More details below.

While it would be best to have this behaviour (allow duplicate keys) by default for all conversions, I am conscious not to break any projects currently using these files. This is tricker with the fact that not all keys in all objects are consistently arrays, so code will need to be updated to support the fact that *any* key could have multiple values represented as an array, or a singular value represented without an array.

As a result, only `items_game.json` will be affected by this change for now, which is described below:

- If duplicate keys are encountered, the values of the JSON hash values for that key are changed into arrays. This is similar to hash-map key collision resolution. Multiple values of that key are appended to the array on first-in basis.
- Note that this may result in duplicate data as it is possible for Valve to specify duplicate keys in error.
- **Consumers of this data should take the first value of an array if they do not expect to be consuming multiple values for a particular key.**

This PR also adds a command line arugment to `update.rb`. This allows someone to run the update script without extracting the VPK and only runs the VDF > JSON generation step. This requires that the VDF's already exist in the corresponding paths (they are checked into this repo). 

To regenerate the JSON files, simply run `ruby update.rb --skip-vpk`.