### PR TITLE
Force encoding when reading dota/scripts/items/items_game.json

### DIFF
--- a/league.rb
+++ b/league.rb
@@ -11,7 +11,7 @@ begin
   puts "Reading #{ITEMS_GAME_JSON}"
   output = Hash.new
 
-  json_data = File.read(ITEMS_GAME_JSON)
+  json_data = File.read(ITEMS_GAME_JSON, :encoding => 'iso-8859-1')
   d = JSON.parse(json_data)
   puts "Successfully parsed #{ITEMS_GAME_JSON}. Iterating through ticket econ items..."
   d["items_game"]["items"].each do |k, v|


### PR DESCRIPTION
Ruby complained that it couldn't parse the JSON from `dota/scripts/items/items_game.json` because it found an invalid character: `"\xE6" on US-ASCII`. Forcing the encoding to be `iso-8859-1` fixes it.